### PR TITLE
✨ Brands added to home-assistant/brands

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,5 +32,3 @@ jobs:
         uses: hacs/action@d556e736723344f83838d08488c983a15381059a # 22.5.0
         with:
           category: integration
-          # Remove this 'ignore' key when you have added brand images for your integration to https://github.com/home-assistant/brands
-          ignore: brands


### PR DESCRIPTION
Waiting for [home-assistant/brands#7074](https://github.com/home-assistant/brands/pull/7074) to be merged

> Removed `ignore: brands` from HACS validation, so will fail in the meantime